### PR TITLE
Fix: Remove leftover reset button from PopUp Tour debugging session

### DIFF
--- a/src/components/desktop/__tests__/desktop-layout-tour.test.tsx
+++ b/src/components/desktop/__tests__/desktop-layout-tour.test.tsx
@@ -6,13 +6,11 @@ import DesktopLayout from '../desktop-layout'
 // Mock the tour hook to control tour behavior in tests
 const mockStartDesktopTour = jest.fn()
 const mockShouldShowTour = jest.fn(() => true)
-const mockResetTourPreferences = jest.fn()
 
 jest.mock('@/lib/hooks/use-tour', () => ({
   useTour: () => ({
     startDesktopTour: mockStartDesktopTour,
-    shouldShowTour: mockShouldShowTour,
-    resetTourPreferences: mockResetTourPreferences
+    shouldShowTour: mockShouldShowTour
   })
 }))
 
@@ -93,24 +91,6 @@ describe('DesktopLayout Tour Integration - User Behavior', () => {
     })
   })
 
-  describe('User can manage tour preferences', () => {
-    it('provides reset button for tour preferences', () => {
-      render(<DesktopLayout />)
-      
-      // Users should be able to reset their preferences
-      expect(screen.getByText('RESET')).toBeInTheDocument()
-    })
-
-    it('allows users to reset tour preferences', () => {
-      render(<DesktopLayout />)
-      
-      const resetButton = screen.getByText('RESET')
-      fireEvent.click(resetButton)
-      
-      // User click should reset preferences
-      expect(mockResetTourPreferences).toHaveBeenCalledTimes(1)
-    })
-  })
 
   describe('User sees proper tour targets', () => {
     it('provides pattern selector as tour target', () => {
@@ -180,14 +160,10 @@ describe('DesktopLayout Tour Integration - User Behavior', () => {
       render(<DesktopLayout />)
       
       const replayButton = screen.getByText('REPLAY TOUR')
-      const resetButton = screen.getByText('RESET')
       
-      // Tour control buttons should be accessible
+      // Tour control button should be accessible
       expect(replayButton).toBeInTheDocument()
       expect(replayButton.tagName).toBe('BUTTON')
-      expect(resetButton).toBeInTheDocument()
-      expect(resetButton.tagName).toBe('BUTTON')
-      expect(resetButton).toHaveAttribute('title') // Has tooltip for accessibility
     })
 
     it('maintains keyboard navigation for tour controls', () => {
@@ -224,8 +200,7 @@ describe('DesktopLayout Tour Integration - User Behavior', () => {
       jest.doMock('@/lib/hooks/use-tour', () => ({
         useTour: () => ({
           startDesktopTour: undefined,
-          shouldShowTour: () => false,
-          resetTourPreferences: undefined
+          shouldShowTour: () => false
         })
       }))
       

--- a/src/components/desktop/desktop-layout-header.tsx
+++ b/src/components/desktop/desktop-layout-header.tsx
@@ -7,13 +7,11 @@ import { ThemeToggle } from "@/components/ui/theme-toggle"
 interface DesktopLayoutHeaderProps {
   shouldShowTour: () => boolean
   startDesktopTour: () => void
-  resetTourPreferences: () => void
 }
 
 export function DesktopLayoutHeader({
   shouldShowTour,
-  startDesktopTour,
-  resetTourPreferences
+  startDesktopTour
 }: DesktopLayoutHeaderProps) {
   return (
     <header className="relative border-b border-form p-6 bg-white/80 backdrop-blur-sm">
@@ -31,14 +29,6 @@ export function DesktopLayoutHeader({
               REPLAY TOUR
             </button>
           )}
-          {/* AIDEV-NOTE: Debug button to reset tour preferences */}
-          <button
-            onClick={resetTourPreferences}
-            className="border border-border bg-secondary hover:bg-secondary/80 text-secondary-foreground px-2 py-1 text-xs font-mono transition-colors"
-            title="Reset tour preferences (dev only)"
-          >
-            RESET
-          </button>
           <ThemeToggle />
         </div>
       </div>

--- a/src/components/desktop/desktop-layout.tsx
+++ b/src/components/desktop/desktop-layout.tsx
@@ -34,7 +34,7 @@ export default function DesktopLayout() {
   const { content: educationalContent } = useEducationalContent(selectedPatternId)
   
   // AIDEV-NOTE: Tour system integration with first-visit detection
-  const { startDesktopTour, shouldShowTour, resetTourPreferences } = useTour()
+  const { startDesktopTour, shouldShowTour } = useTour()
   
   // Check if educational content is available for current pattern
   const availableEducationalPatterns = getAllPatternIds()
@@ -94,7 +94,6 @@ export default function DesktopLayout() {
       <DesktopLayoutHeader
         shouldShowTour={shouldShowTour}
         startDesktopTour={startDesktopTour}
-        resetTourPreferences={resetTourPreferences}
       />
 
       <div className="flex relative">


### PR DESCRIPTION
## Summary
- Removes debug RESET button that was accidentally left in the desktop header UI from PopUp Tour debugging session
- Cleans up component interfaces and test cases that referenced the removed functionality  
- Preserves underlying `resetTourPreferences()` utility function for legitimate infrastructure use

## Changes Made
- **Desktop Header Component**: Removed RESET button UI and `resetTourPreferences` prop
- **Desktop Layout Component**: Updated to no longer pass the reset function to header
- **Test Suite**: Removed test cases that checked for the debug button functionality

## Test Plan
- [x] All existing tests pass (603 tests, 43 test suites)
- [x] Lint and build checks pass
- [x] Storybook builds successfully  
- [x] Tour functionality still works correctly (REPLAY TOUR button remains)
- [x] No functional regressions - debug button removal only

🤖 Generated with [Claude Code](https://claude.ai/code)